### PR TITLE
Create kdd.hpp on the 27. Remove Element

### DIFF
--- a/leetcode/easy/27_remove_element/kdd.hpp
+++ b/leetcode/easy/27_remove_element/kdd.hpp
@@ -1,0 +1,36 @@
+// https://leetcode.com/problems/remove-element/
+// Runtime: 0 ms, faster than 100.00% of C++ online submissions for Remove Element.
+// Memory Usage: 8.6 MB, less than 92.65% of C++ online submissions for Remove Element.
+
+class Solution {
+public:
+    template <class Vec, class Iter>
+    void unorderedDeleted(Vec&& vec, Iter&& iter) {
+        if (iter != std::end(vec)) {
+            *iter = std::move(vec.back());
+            vec.pop_back();
+        }
+    }
+    
+    int removeElement(vector<int>& nums, int val) {
+        auto iter = std::begin(nums); 
+        while (iter != std::end(nums)) {
+            iter = std::find(nums.begin(), nums.end(), val);
+            unorderedDeleted(nums, iter);
+        }
+        
+        return nums.size();
+    }
+};
+
+// https://leetcode.com/problems/remove-element/
+// Runtime: 0 ms, faster than 100.00% of C++ online submissions for Remove Element.
+// Memory Usage: 8.6 MB, less than 73.53% of C++ online submissions for Remove Element.
+
+class Solution {
+public:   
+    int removeElement(vector<int>& nums, int val) {
+        nums.erase(std::remove(nums.begin(), nums.end(), val), nums.end());
+        return nums.size();
+    }
+};


### PR DESCRIPTION
C++에서 최근에 이슈가 되고 있는 게 있어서 한 번 두 버전을 올려봤습니다. ^^ 하나는 Erase-remove idiom 기반의 Ordered erase-remove(C++에서는 erase와 remove를 구분합니다. 이게 다 성능 때문이죠.) 방식이라고 해서 사실상 de facto가 된 std::vector<T> 내부의 삭제 기법입니다. 순서가 지켜진 상태로 원소를 삭제하는데, 코드가 굉장히 짧지만 최적화가 되었다고 해도 그다지 빠른 방법은 아니죠. 

반면에 코드가 긴 버전이 최근에 몇몇 진영에서 추가해줬으면 좋겠다고 이야기하는 Unordered erase-remove 방식인데, 이렇게 하면 std::vector 내의 원소 삭제가 무려 O(1)에 가능하다는 장점이 있습니다. 이 문제는 딱히 성능 차이가 보이지 않을만큼 테스트 케이스가 조금 부실하지 않나 싶긴 하지만... 그냥 주저리를 좀 써보았습니다. ^^